### PR TITLE
Release 2.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2" %}
+{% set version = "2.3" %}
 
 package:
   name: tmux
@@ -7,7 +7,7 @@ package:
 source:
   fn: tmux-{{ version }}.tar.gz
   url: https://github.com/tmux/tmux/archive/{{ version }}.tar.gz
-  sha256: f17f4d98454bd87d0065047ef0a4cf78da180ec5e957124bedee3a5fdd72a598
+  sha256: 8847b6f7b93a095b1d5dcd318bc6837b86ebb42d09394d17c231590758cd9386
 
 build:
   number: 0


### PR DESCRIPTION
```
CHANGES FROM 2.2 to 2.3 29 September 2016

Incompatible Changes
====================

None.

Normal Changes
==============

* New option 'pane-border-status' to add text in the pane borders.
* Support for hooks on commands: 'after' and 'before' hooks.
* 'source-file' understands '-q' to suppress errors for nonexistent files.
* Lots of UTF8 improvements, especially on MacOS.
* 'window-status-separator' understands #[] expansions.
* 'split-window' understands '-f' for performing a full-width split.
* Allow report count to be specified when using 'bind-key -R'.
* 'set -a' for appending to user options (@foo) is now supported.
* 'display-panes' can now accept a command to run, rather than always
  selecting the pane.
```

cc @frol @scopatz