### PR TITLE
use release tarball instead of archive

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Needed for Linux build to work.
-export CFLAGS="-I${PREFIX}/include ${CFLAGS}"
-export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS}"
-export LDFLAGS="-L${PREFIX}/lib ${LDFLAGS}"
-
 ./configure --prefix=$PREFIX
 make
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-chmod +x ./autogen.sh
-
 # Needed for Linux build to work.
 export CFLAGS="-I${PREFIX}/include ${CFLAGS}"
 export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS}"
 export LDFLAGS="-L${PREFIX}/lib ${LDFLAGS}"
 
-./autogen.sh
 ./configure --prefix=$PREFIX
 make
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
 {% set version = "2.7" %}
-{% set sha256 = "89e4774db7d238b1ee515c4527ef90153f0c3cd8ad3e3fde5c01fbbb27fd01a6" %}
+{% set sha256 = "9ded7d100313f6bc5a87404a4048b3745d61f2332f99ec1400a7c4ed9485d452" %}
 
 package:
   name: tmux
   version: {{ version }}
 
 source:
-  url: https://github.com/tmux/tmux/archive/{{ version }}.tar.gz
+  url: https://github.com/tmux/tmux/releases/download/{{ version }}/tmux-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
mostly because `tmux -V` is reporting `tmux master` as it is, but there might also be other slight changes.
also, configure is already autogen'ed on the release tarball